### PR TITLE
[BACKLOG-5249] - BA Server call endpoint: use auth from BA server thr…

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -28,7 +28,7 @@
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="1.1" transitive="false"/>
 
     <dependency org="dom4j" name="dom4j" rev="1.6.1"/>
-    <dependency org="javax.servlet" name="servlet-api" rev="2.4" transitive="false" conf="test, default->default"/>
+    <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" transitive="false" conf="test, default->default"/>
 
     <dependency org="org.springframework"          name="spring"                 rev="2.5.6"         transitive="false"/>
     <dependency org="org.springframework"          name="spring-beans"           rev="2.5.6"         transitive="false"/>

--- a/src/org/pentaho/di/baserver/utils/web/HttpConnectionHelper.java
+++ b/src/org/pentaho/di/baserver/utils/web/HttpConnectionHelper.java
@@ -36,6 +36,7 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequestEvent;
+import javax.servlet.DispatcherType;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -133,7 +134,7 @@ public class HttpConnectionHelper {
 
       final InternalHttpServletRequest servletRequest = new InternalHttpServletRequest( httpMethod,
           fullyQualifiedServerURL, "/api", endpointPath );
-      servletRequest.setAttribute( "org.apache.catalina.core.DISPATCHER_TYPE", 2 ); //FORWARD = 2
+      servletRequest.setAttribute( "org.apache.catalina.core.DISPATCHER_TYPE", DispatcherType.FORWARD ); //FORWARD = 2
 
       try {
         insertParameters( httpMethod, queryParameters, servletRequest );

--- a/src/org/pentaho/di/baserver/utils/web/InternalHttpServletRequest.java
+++ b/src/org/pentaho/di/baserver/utils/web/InternalHttpServletRequest.java
@@ -18,11 +18,20 @@
 
 package org.pentaho.di.baserver.utils.web;
 
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.ServletContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
+import javax.servlet.http.HttpUpgradeHandler;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -37,6 +46,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Collection;
 
 public class InternalHttpServletRequest implements HttpServletRequest {
 
@@ -307,6 +317,36 @@ public class InternalHttpServletRequest implements HttpServletRequest {
   @Override public boolean isRequestedSessionIdFromUrl() {
     return false;
   }
+
+  @Override public AsyncContext getAsyncContext() { return null; }
+
+  @Override public AsyncContext startAsync() {return null; }
+
+  @Override public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {return null; }
+
+  @Override public boolean isAsyncSupported() {return false; }
+
+  @Override public boolean isAsyncStarted() {return false; }
+
+  @Override public  ServletContext getServletContext() {return null; }
+
+  @Override public DispatcherType getDispatcherType() { return null; }
+
+  @Override public Part getPart(String name) throws IOException, ServletException { return null; }
+
+  @Override public Collection<Part> getParts() throws IOException, ServletException { return null; }
+
+  @Override public void logout() throws ServletException { }
+
+  @Override public void login(String username, String password) throws ServletException {  }
+
+  @Override public boolean authenticate(HttpServletResponse httpServletResponse) throws IOException, ServletException { return false; }
+
+  @Override public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException { return null; }
+
+  @Override public String changeSessionId() { return null; }
+
+  @Override public long getContentLengthLong() { return 0; }
 
 
 

--- a/src/org/pentaho/di/baserver/utils/web/InternalHttpServletResponse.java
+++ b/src/org/pentaho/di/baserver/utils/web/InternalHttpServletResponse.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.util.Collection;
 import java.util.Locale;
 
 public class InternalHttpServletResponse implements HttpServletResponse {
@@ -65,6 +66,7 @@ public class InternalHttpServletResponse implements HttpServletResponse {
   public boolean isWriterAccessAllowed() {
     return true;
   }
+
 
   @Override
   public ServletOutputStream getOutputStream() {
@@ -119,6 +121,14 @@ public class InternalHttpServletResponse implements HttpServletResponse {
   @Override public void setCharacterEncoding( String s ) {
 
   }
+
+  @Override public String getHeader(String name) { return ""; }
+
+  @Override public Collection<String> getHeaders(String name) { return null; }
+
+  @Override public Collection<String> getHeaderNames() { return null; }
+
+  @Override public void setContentLengthLong(long contentLengthLong) { };
 
   @Override
   public String getContentType() {

--- a/src/org/pentaho/di/baserver/utils/web/ServletInputStreamWrapper.java
+++ b/src/org/pentaho/di/baserver/utils/web/ServletInputStreamWrapper.java
@@ -18,6 +18,7 @@
 
 package org.pentaho.di.baserver.utils.web;
 
+import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,4 +45,10 @@ public final class ServletInputStreamWrapper extends ServletInputStream {
     super.close();
     this.inputStream.close();
   }
+
+  @Override public boolean isFinished() { return false; }
+
+  @Override public boolean isReady() { return false; }
+
+  @Override public void setReadListener(ReadListener readListener) { }
 }

--- a/src/org/pentaho/di/baserver/utils/web/ServletOutputStreamWrapper.java
+++ b/src/org/pentaho/di/baserver/utils/web/ServletOutputStreamWrapper.java
@@ -19,6 +19,7 @@
 package org.pentaho.di.baserver.utils.web;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -50,4 +51,8 @@ public class ServletOutputStreamWrapper extends ServletOutputStream {
     super.close();
     this.outputStream.close();
   }
+
+  @Override public  boolean isReady() { return false; }
+  
+  @Override public void setWriteListener(WriteListener writeListener) { }
 }


### PR DESCRIPTION
…ows: java.lang.Integer cannot be cast to javax.servlet.DispatcherType

- upgraded version of javax.servlet to version 3.1.0 as used in the Pentaho Platform;
- added the necessary overrides to comply with the new version;