### PR TITLE
[BACKLOG-5249] - BA Server call endpoint: use auth from BA server thr…

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -28,7 +28,7 @@
     <dependency org="com.googlecode.json-simple" name="json-simple" rev="1.1" transitive="false"/>
 
     <dependency org="dom4j" name="dom4j" rev="1.6.1"/>
-    <dependency org="javax.servlet" name="servlet-api" rev="2.4" transitive="false" conf="test, default->default"/>
+    <dependency org="javax.servlet" name="javax.servlet-api" rev="3.0.1" transitive="false" conf="test, default->default"/>
 
     <dependency org="org.springframework"          name="spring"                 rev="2.5.6"         transitive="false"/>
     <dependency org="org.springframework"          name="spring-beans"           rev="2.5.6"         transitive="false"/>

--- a/src/org/pentaho/di/baserver/utils/web/HttpConnectionHelper.java
+++ b/src/org/pentaho/di/baserver/utils/web/HttpConnectionHelper.java
@@ -36,6 +36,7 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequestEvent;
+import javax.servlet.DispatcherType;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -133,7 +134,7 @@ public class HttpConnectionHelper {
 
       final InternalHttpServletRequest servletRequest = new InternalHttpServletRequest( httpMethod,
           fullyQualifiedServerURL, "/api", endpointPath );
-      servletRequest.setAttribute( "org.apache.catalina.core.DISPATCHER_TYPE", 2 ); //FORWARD = 2
+      servletRequest.setAttribute( "org.apache.catalina.core.DISPATCHER_TYPE", DispatcherType.FORWARD ); //FORWARD = 2
 
       try {
         insertParameters( httpMethod, queryParameters, servletRequest );

--- a/src/org/pentaho/di/baserver/utils/web/InternalHttpServletRequest.java
+++ b/src/org/pentaho/di/baserver/utils/web/InternalHttpServletRequest.java
@@ -18,11 +18,19 @@
 
 package org.pentaho.di.baserver.utils.web;
 
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.ServletContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Part;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -37,6 +45,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Collection;
 
 public class InternalHttpServletRequest implements HttpServletRequest {
 
@@ -307,6 +316,30 @@ public class InternalHttpServletRequest implements HttpServletRequest {
   @Override public boolean isRequestedSessionIdFromUrl() {
     return false;
   }
+
+  @Override public AsyncContext getAsyncContext() { return null; }
+
+  @Override public AsyncContext startAsync() {return null; }
+
+  @Override public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {return null; }
+
+  @Override public boolean isAsyncSupported() {return false; }
+
+  @Override public boolean isAsyncStarted() {return false; }
+
+  @Override public  ServletContext getServletContext() {return null; }
+
+  @Override public DispatcherType getDispatcherType() { return null; }
+
+  @Override public Part getPart(String name) throws IOException, ServletException { return null; }
+
+  @Override public Collection<Part> getParts() throws IOException, ServletException { return null; }
+
+  @Override public void logout() throws ServletException { }
+
+  @Override public void login(String username, String password) throws ServletException {  }
+
+  @Override public boolean authenticate(HttpServletResponse httpServletResponse) throws IOException, ServletException { return false; }
 
 
 

--- a/src/org/pentaho/di/baserver/utils/web/InternalHttpServletResponse.java
+++ b/src/org/pentaho/di/baserver/utils/web/InternalHttpServletResponse.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.util.Collection;
 import java.util.Locale;
 
 public class InternalHttpServletResponse implements HttpServletResponse {
@@ -65,6 +66,7 @@ public class InternalHttpServletResponse implements HttpServletResponse {
   public boolean isWriterAccessAllowed() {
     return true;
   }
+
 
   @Override
   public ServletOutputStream getOutputStream() {
@@ -119,6 +121,12 @@ public class InternalHttpServletResponse implements HttpServletResponse {
   @Override public void setCharacterEncoding( String s ) {
 
   }
+
+  @Override public String getHeader(String name) { return ""; }
+
+  @Override public Collection<String> getHeaders(String name) { return null; }
+
+  @Override public Collection<String> getHeaderNames() { return null; }
 
   @Override
   public String getContentType() {


### PR DESCRIPTION
…ows: java.lang.Integer cannot be cast to javax.servlet.DispatcherType

- upgraded version of javax.servlet to version 3.1.0 as used in the Pentaho Platform;
- added the necessary overrides  to comply with the new version;