### PR TITLE
[BACKLOG-8388] - Upgrade Jersey to 1.19.1 across the suite for Java 8 compatibility

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -33,8 +33,8 @@
     <dependency org="org.springframework"          name="spring"                 rev="2.5.6"         transitive="false"/>
     <dependency org="org.springframework"          name="spring-beans"           rev="2.5.6"         transitive="false"/>
 
-    <dependency org="com.sun.jersey" name="jersey-servlet" rev="1.16" transitive="false" conf="test, default->default" />
-    <dependency org="com.sun.jersey.contribs" name="jersey-spring" rev="1.16" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-servlet" rev="1.19.1" transitive="false" conf="test, default->default" />
+    <dependency org="com.sun.jersey.contribs" name="jersey-spring" rev="1.19.1" transitive="false"/>
 
     <!--<dependency org="org.springframework"          name="spring-context"         rev="2.5.6"         transitive="false"/>
     <dependency org="org.springframework"          name="spring-context-support" rev="2.5.6"         transitive="false"/>
@@ -52,7 +52,7 @@
     <dependency org="org.owasp.esapi"                  name="esapi"                rev="2.0.1"           transitive="false" conf="test->default"/>
     <dependency org="org.apache.commons" name="commons-vfs2" rev="2.1-20150824" transitive="false" conf="test->default"/>
     <dependency org="javax.ws.rs" name="jsr311-api" rev="1.1.1" transitive="false" conf="test->default"/>
-    <dependency org="com.sun.jersey" name="jersey-core" rev="1.16" conf="test->default"/>
-    <dependency org="com.sun.jersey" name="jersey-server" rev="1.16" conf="test->default"/>
+    <dependency org="com.sun.jersey" name="jersey-core" rev="1.19.1" conf="test->default" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-server" rev="1.19.1" conf="test->default" transitive="false"/>
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor