### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/core/src/main/java/org/pentaho/di/baserver/utils/web/HttpConnectionHelper.java
+++ b/core/src/main/java/org/pentaho/di/baserver/utils/web/HttpConnectionHelper.java
@@ -39,11 +39,11 @@ import org.pentaho.platform.web.servlet.JAXRSPluginServlet;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.web.context.request.RequestContextListener;
 
-import javax.servlet.DispatcherType;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequestEvent;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequestEvent;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;

--- a/core/src/main/java/org/pentaho/di/baserver/utils/web/InternalHttpServletRequest.java
+++ b/core/src/main/java/org/pentaho/di/baserver/utils/web/InternalHttpServletRequest.java
@@ -13,19 +13,21 @@
 
 package org.pentaho.di.baserver.utils.web;
 
-import javax.servlet.AsyncContext;
-import javax.servlet.DispatcherType;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.Part;
+import jakarta.servlet.ServletConnection;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.Part;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -300,6 +302,11 @@ public class InternalHttpServletRequest implements HttpServletRequest {
     return null;
   }
 
+  @Override
+  public String changeSessionId() {
+    return null;
+  }
+
   @Override public boolean isRequestedSessionIdValid() {
     return false;
   }
@@ -312,7 +319,7 @@ public class InternalHttpServletRequest implements HttpServletRequest {
     return false;
   }
 
-  @Override public boolean isRequestedSessionIdFromUrl() {
+  public boolean isRequestedSessionIdFromUrl() {
     return false;
   }
 
@@ -344,7 +351,27 @@ public class InternalHttpServletRequest implements HttpServletRequest {
     return null;
   }
 
+  @Override
+  public String getRequestId() {
+    return null;
+  }
+
+  @Override
+  public String getProtocolRequestId() {
+    return null;
+  }
+
+  @Override
+  public ServletConnection getServletConnection() {
+    return null;
+  }
+
   @Override public Part getPart( String name ) throws IOException, ServletException {
+    return null;
+  }
+
+  @Override
+  public <T extends HttpUpgradeHandler> T upgrade( Class<T> aClass ) throws IOException, ServletException {
     return null;
   }
 
@@ -406,7 +433,6 @@ public class InternalHttpServletRequest implements HttpServletRequest {
     return null;
   }
 
-  @Override
   public String getRealPath( String path ) {
     return null;
   }
@@ -459,6 +485,11 @@ public class InternalHttpServletRequest implements HttpServletRequest {
   @Override
   public int getContentLength() {
     return ( this.content != null ? this.content.length : -1 );
+  }
+
+  @Override
+  public long getContentLengthLong() {
+    return 0;
   }
 
   @Override

--- a/core/src/main/java/org/pentaho/di/baserver/utils/web/InternalHttpServletResponse.java
+++ b/core/src/main/java/org/pentaho/di/baserver/utils/web/InternalHttpServletResponse.java
@@ -13,9 +13,9 @@
 
 package org.pentaho.di.baserver.utils.web;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -107,6 +107,11 @@ public class InternalHttpServletResponse implements HttpServletResponse {
   @Override
   public void setContentLength( int contentLength ) {
     this.contentLength = contentLength;
+  }
+
+  @Override
+  public void setContentLengthLong( long l ) {
+
   }
 
   @Override public String getCharacterEncoding() {
@@ -256,7 +261,6 @@ public class InternalHttpServletResponse implements HttpServletResponse {
 
   }
 
-  @Override
   public void setStatus( int status, String errorMessage ) {
     this.status = status;
     this.errorMessage = errorMessage;

--- a/core/src/main/java/org/pentaho/di/baserver/utils/web/ServletInputStreamWrapper.java
+++ b/core/src/main/java/org/pentaho/di/baserver/utils/web/ServletInputStreamWrapper.java
@@ -13,7 +13,8 @@
 
 package org.pentaho.di.baserver.utils.web;
 
-import javax.servlet.ServletInputStream;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -38,5 +39,20 @@ public final class ServletInputStreamWrapper extends ServletInputStream {
   public void close() throws IOException {
     super.close();
     this.inputStream.close();
+  }
+
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+
+  @Override
+  public boolean isReady() {
+    return false;
+  }
+
+  @Override
+  public void setReadListener( ReadListener readListener ) {
+
   }
 }

--- a/core/src/main/java/org/pentaho/di/baserver/utils/web/ServletOutputStreamWrapper.java
+++ b/core/src/main/java/org/pentaho/di/baserver/utils/web/ServletOutputStreamWrapper.java
@@ -13,7 +13,8 @@
 
 package org.pentaho.di.baserver.utils.web;
 
-import javax.servlet.ServletOutputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -44,5 +45,15 @@ public class ServletOutputStreamWrapper extends ServletOutputStream {
   public void close() throws IOException {
     super.close();
     this.outputStream.close();
+  }
+
+  @Override
+  public boolean isReady() {
+    return false;
+  }
+
+  @Override
+  public void setWriteListener( WriteListener writeListener ) {
+
   }
 }

--- a/core/src/test/java/org/pentaho/di/baserver/utils/web/HttpConnectionHelperTest.java
+++ b/core/src/test/java/org/pentaho/di/baserver/utils/web/HttpConnectionHelperTest.java
@@ -34,9 +34,9 @@ import org.pentaho.platform.api.engine.IPluginManager;
 import org.pentaho.platform.web.servlet.JAXRSPluginServlet;
 import org.springframework.beans.factory.ListableBeanFactory;
 
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/core/src/test/java/org/pentaho/di/baserver/utils/web/InternalHttpServletRequestTest.java
+++ b/core/src/test/java/org/pentaho/di/baserver/utils/web/InternalHttpServletRequestTest.java
@@ -16,9 +16,9 @@ package org.pentaho.di.baserver.utils.web;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Enumeration;
 
 import static junit.framework.Assert.*;

--- a/core/src/test/java/org/pentaho/di/baserver/utils/web/InternalHttpServletResponseTest.java
+++ b/core/src/test/java/org/pentaho/di/baserver/utils/web/InternalHttpServletResponseTest.java
@@ -16,8 +16,8 @@ package org.pentaho.di.baserver.utils.web;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,6 @@
     <pdi.version>11.0.0.0-SNAPSHOT</pdi.version>
     <metastore.version>11.0.0.0-SNAPSHOT</metastore.version>
 
-    <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
-    <jersey.version>2.44</jersey.version>
     <org.eclipse.swt.gtk.linux.x86_64.version>4.6</org.eclipse.swt.gtk.linux.x86_64.version>
 
     <!-- 'TEST' SCOPED DEPS -->
@@ -151,9 +149,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>${javax.servlet-api.version}</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -232,7 +230,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.ext</groupId>
-      <artifactId>jersey-spring5</artifactId>
+      <artifactId>jersey-spring6</artifactId>
       <version>${jersey.version}</version>
       <exclusions>
         <exclusion>
@@ -333,9 +331,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${jaxrs.version}</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${jakarta.ws.rs-api.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -43,17 +43,14 @@
     <metastore.version>11.0.0.0-SNAPSHOT</metastore.version>
 
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
-    <jersey-servlet.version>1.19.1</jersey-servlet.version>
-    <jersey-spring.version>1.19.1</jersey-spring.version>
+    <jersey.version>2.44</jersey.version>
     <org.eclipse.swt.gtk.linux.x86_64.version>4.6</org.eclipse.swt.gtk.linux.x86_64.version>
 
     <!-- 'TEST' SCOPED DEPS -->
     <junit.version>4.13.2</junit.version>
     <mockito-core.version>5.10.0</mockito-core.version>
     <encoder.version>1.2</encoder.version>
-    <jsr311-api.version>1.1.1</jsr311-api.version>
-    <jersey-core.version>1.19.1</jersey-core.version>
-    <jersey-server.version>1.19.1</jersey-server.version>
+    <jaxrs.version>2.1</jaxrs.version>
     <slf4j-api.version>1.7.7</slf4j-api.version>
     <commons-lang.version>2.6</commons-lang.version>
     <eclipse.jface.version>3.33.0</eclipse.jface.version>
@@ -179,9 +176,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-servlet</artifactId>
-      <version>${jersey-servlet.version}</version>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet</artifactId>
+      <version>${jersey.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -189,11 +186,54 @@
         </exclusion>
       </exclusions>
     </dependency>
-
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-spring</artifactId>
-      <version>${jersey-spring.version}</version>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-servlet-core</artifactId>
+      <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+      <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+      <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+      <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.ext</groupId>
+      <artifactId>jersey-spring5</artifactId>
+      <version>${jersey.version}</version>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>
@@ -294,34 +334,8 @@
 
     <dependency>
       <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <version>${jsr311-api.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-core</artifactId>
-      <version>${jersey-core.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-server</artifactId>
-      <version>${jersey-core.version}</version>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>${jaxrs.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
This pull request updates the project to use Jakarta EE APIs instead of Java EE APIs. It includes changes to replace `javax.servlet` imports with `jakarta.servlet`, updates the `pom.xml` dependencies to align with Jakarta EE, and introduces new method overrides to support Jakarta Servlet features.

### Migration to Jakarta EE

* Replaced all `javax.servlet` imports with `jakarta.servlet` in multiple files, including `HttpConnectionHelper.java`, `InternalHttpServletRequest.java`, `InternalHttpServletResponse.java`, `ServletInputStreamWrapper.java`, and `ServletOutputStreamWrapper.java`. This ensures compatibility with Jakarta EE APIs. [[1]](diffhunk://#diff-31d113448a082a74a628e303561f07fd943fe04ce72401c87720bd9b7f1599dbL42-R46) [[2]](diffhunk://#diff-ce3f1e0725c3c525130fc5cdb81c1e386f278480e2b29cc88af250724a285dbbL16-R30) [[3]](diffhunk://#diff-e5efc05d99580ba3439189c6b4407f587b69472542987a2c94f18a7afe232612L16-R18) [[4]](diffhunk://#diff-0590d54c5a0da795f7011cd69be869e02202c23a987f9afe7e5b323950414ea4L16-R17) [[5]](diffhunk://#diff-bfb22632b8d40effce0020831dd90a5862827e0147c96f0c05f322694a9b4dd6L16-R17)

* Updated `pom.xml` to replace Java EE dependencies (`javax.servlet-api`, `jersey-servlet`, `jersey-spring`, `jsr311-api`, etc.) with Jakarta EE equivalents (`jakarta.servlet-api`, `jersey-container-servlet`, `jersey-spring6`, etc.). Added exclusions to prevent conflicts. (F8a3b1ddL13R13, [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L157-R154) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L182-R234) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L296-R336)

### Support for Jakarta Servlet Features

* Added method overrides in `InternalHttpServletRequest.java` to support Jakarta Servlet features like `changeSessionId`, `getRequestId`, `getProtocolRequestId`, `getServletConnection`, and `upgrade`. These methods return default values or null for now. [[1]](diffhunk://#diff-ce3f1e0725c3c525130fc5cdb81c1e386f278480e2b29cc88af250724a285dbbR305-R309) [[2]](diffhunk://#diff-ce3f1e0725c3c525130fc5cdb81c1e386f278480e2b29cc88af250724a285dbbR354-R377)

* Added method overrides in `ServletInputStreamWrapper.java` and `ServletOutputStreamWrapper.java` for Jakarta Servlet features such as `isFinished`, `isReady`, `setReadListener`, and `setWriteListener`. These methods currently return default values or perform no actions. [[1]](diffhunk://#diff-0590d54c5a0da795f7011cd69be869e02202c23a987f9afe7e5b323950414ea4R43-R57) [[2]](diffhunk://#diff-bfb22632b8d40effce0020831dd90a5862827e0147c96f0c05f322694a9b4dd6R49-R58)

### Test Updates

* Updated test files (`HttpConnectionHelperTest.java`, `InternalHttpServletRequestTest.java`, `InternalHttpServletResponseTest.java`) to replace `javax.servlet` imports with `jakarta.servlet`. This ensures test compatibility with the updated API. [[1]](diffhunk://#diff-455d08ab999546794398e1d6bacda5eb50fa949700c0ecb1945ddd42e0ca515cL37-R39) [[2]](diffhunk://#diff-8560e4340c6477fb9a897152371fb87740eef8e9abbeb7cfebd2159ebda00f0dL19-R21) [[3]](diffhunk://#diff-0b89b568f05cb67499f6acd44666b09eb9a3bbd7e0a25218a24b0736e198cac9L19-R20)